### PR TITLE
Changed to 400ms

### DIFF
--- a/DingPics.lua
+++ b/DingPics.lua
@@ -3,6 +3,6 @@ frame:Hide()
 frame:RegisterEvent("PLAYER_LEVEL_UP")
 frame:SetScript("OnEvent", function (self, event)
 	-- wait a bit so the yellow animation appears 300ms seems good
-	C_Timer.After(.3, Screenshot)
+	C_Timer.After(.4, Screenshot)
 end
 )


### PR DESCRIPTION
Changed to 400ms as it wasnt catching the yellow animation. Unless ive missed the point and its supposed to miss the yellow bit? But it always seemed to take the screenshot just before the effect happened. 400ms seems to work fine. Could be my hardware speed maybe?