### PR TITLE
Change delay to 1 second and display the output of /played in chat

### DIFF
--- a/DingPics.lua
+++ b/DingPics.lua
@@ -2,7 +2,8 @@ local frame = CreateFrame("Frame")
 frame:Hide()
 frame:RegisterEvent("PLAYER_LEVEL_UP")
 frame:SetScript("OnEvent", function (self, event)
-	-- wait a bit so the yellow animation appears 300ms seems good
-	C_Timer.After(.3, Screenshot)
+	-- wait a bit so the yellow animation appears
+	RequestTimePlayed()
+	C_Timer.After(1, Screenshot)
 end
 )


### PR DESCRIPTION
300ms was far too quick to catch the yellow animation for me. In fact it was too quick to even have the XP bar update. Also seeing /played might be nice.

Example screenshots:

**with 300ms delay**:

![WoWScrnShot_082719_051712](https://user-images.githubusercontent.com/5822375/65285175-58778e00-db44-11e9-89d6-2c58f570d02e.jpg)

**With... I think 500ms delay?:**

![WoWScrnShot_082719_203946](https://user-images.githubusercontent.com/5822375/65285105-2403d200-db44-11e9-95c8-7c416f2a46d3.jpg)

**1 second delay:**

![WoWScrnShot_082819_121330](https://user-images.githubusercontent.com/5822375/65285143-3da51980-db44-11e9-83c9-7fbf06cd5a35.jpg)

**1 second delay and /played:**

![WoWScrnShot_092019_010822](https://user-images.githubusercontent.com/5822375/65285147-44339100-db44-11e9-8d57-87594aa57581.jpg)
